### PR TITLE
feat(common): ✨ add a config for custom theme

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3,11 +3,7 @@ import ReactDOM from 'react-dom';
 import Router from './routes/Router';
 import { BrowserRouter } from 'react-router-dom';
 import { ChakraProvider } from '@chakra-ui/react';
-import { extendTheme } from '@chakra-ui/react';
-
-const theme = extendTheme({
-	colors: {},
-});
+import theme from './config/theme/themeProvider';
 
 ReactDOM.render(
 	<React.StrictMode>

--- a/src/config/theme/theme.ts
+++ b/src/config/theme/theme.ts
@@ -1,0 +1,30 @@
+export const theme = {
+	palette: {
+		neutral: {
+			light: '#FFFFFF',
+			dark: '#1A202C',
+		},
+		primary: {
+			100: '#fdd3e3',
+			200: '#fcc5d9',
+			300: '#fbb6d0',
+			400: '#faa7c6',
+			500: '#f999bd',
+			600: '#f98ab3',
+			700: '#f87caa',
+			800: '#f76da0',
+			900: '#de6290',
+		},
+		secondary: {
+			100: '#d5f3ef',
+			200: '#c7efea',
+			300: '#b9ebe5',
+			400: '#aae6df',
+			500: '#9ce2da',
+			600: '#8eded5',
+			700: '#80dacf',
+			800: '#72d6ca',
+			900: '#67c1b6',
+		},
+	},
+};

--- a/src/config/theme/themeProvider.ts
+++ b/src/config/theme/themeProvider.ts
@@ -1,0 +1,22 @@
+import { extendTheme, type ThemeConfig } from '@chakra-ui/react';
+import { theme as customTheme } from './theme';
+
+const config: ThemeConfig = {
+	initialColorMode: 'dark',
+	useSystemColorMode: false,
+};
+
+const styles = {
+	global: (props: { colorMode: string }) => ({
+		'html, body': {
+			color: props.colorMode === 'dark' ? 'neutral.light' : 'neutral.dark',
+			backgroundColor: props.colorMode === 'dark' ? 'neutral.dark' : 'neutral.light',
+		},
+	}),
+};
+
+const colors = customTheme.palette;
+
+const theme = extendTheme({ config, styles, colors });
+
+export default theme;


### PR DESCRIPTION
Le but de la MR c'est d'ajouter une config pour la gestion du theming, création d'un fichier themeProvider qui nous permet de créer toute la logique de theme pour ChakraUI et de l'importer dans l'App.tsx . De cette façon on exporte la palette de couleur dans un fichier à part comme ça : 

![image](https://user-images.githubusercontent.com/43264146/154804753-1e0c9365-cde5-43df-a587-bcbe6ea76bb6.png)
